### PR TITLE
ORA-22 (fix): Update github runner ubuntu version

### DIFF
--- a/.github/workflows/db-cd.yml
+++ b/.github/workflows/db-cd.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   migrate-database:
     name: Run Flyway migrations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SUPABASE_HOST: db.hztrudndwrildnalbcvw.supabase.co
       SUPABASE_PORT: 5432


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a more recent version of the Ubuntu runner for the database migration job.

* [`.github/workflows/db-cd.yml`](diffhunk://#diff-f3f35edc9467ba7e7d0b0cbdd3fd1ec00a047460791ffdf00148442c8ba9dd70L15-R15): Updated the `runs-on` key from `ubuntu-20.04` to `ubuntu-22.04` for the `migrate-database` job, ensuring compatibility with newer features and updates.