### PR TITLE
ORA-22 (fix): Update github runner ubuntu version

### DIFF
--- a/.github/workflows/db-cd.yml
+++ b/.github/workflows/db-cd.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   migrate-database:
     name: Run Flyway migrations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SUPABASE_HOST: db.hztrudndwrildnalbcvw.supabase.co
       SUPABASE_PORT: 5432

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,9 +2,8 @@ name: Frontend CI
 
 on:
   pull_request:
-    paths:
-      - 'crm-ui/**'
-      - '.github/workflows/frontend-ci.yml'
+    branches:
+      - main
   push:
     paths:
       - 'crm-ui/**'


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to align with newer environments and streamline triggers. The most important changes include upgrading the operating system for database migrations and modifying the trigger conditions for the frontend CI workflow.

### Workflow updates:

* [`.github/workflows/db-cd.yml`](diffhunk://#diff-f3f35edc9467ba7e7d0b0cbdd3fd1ec00a047460791ffdf00148442c8ba9dd70L15-R15): Updated the `runs-on` parameter to use `ubuntu-22.04` instead of `ubuntu-20.04` for the `migrate-database` job, ensuring compatibility with newer environments.

* [`.github/workflows/frontend-ci.yml`](diffhunk://#diff-5cd76c2d3da116c3ec33f2a8ce86d739d0fe4e46c0563f2dde614ab8afc41f38L5-R6): Changed the trigger conditions for the `Frontend CI` workflow. The `pull_request` event now triggers only on the `main` branch instead of specific file paths.