### PR TITLE
ORA-26 Change SUPABASE_PORT in db-cd to 5432 for session pooling

### DIFF
--- a/.github/workflows/db-cd.yml
+++ b/.github/workflows/db-cd.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       # Use Supabase pooler instead of direct connection for IPv4 compatibility
       SUPABASE_HOST: aws-0-ap-southeast-1.pooler.supabase.com
-      SUPABASE_PORT: 6543
+      SUPABASE_PORT: 5432
       SUPABASE_USER: postgres.hztrudndwrildnalbcvw
       SUPABASE_DB: postgres
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/db-cd.yml` file. The change updates the `SUPABASE_PORT` environment variable to use port `5432` instead of `6543` for compatibility with the Supabase pooler.