### PR TITLE
ORA-28 Fix completed state fsm transition

### DIFF
--- a/backend/database/migrations/V202507101230__fix_completed_state_transitions.sql
+++ b/backend/database/migrations/V202507101230__fix_completed_state_transitions.sql
@@ -1,0 +1,2 @@
+INSERT INTO senior_sync.fsm_transitions (campaign_name, trigger, source_state, dest_state, guard_name, action_name) VALUES
+('lodging_request', 'FIRSTCHATOPEN', 'COMPLETED', 'START', null, 'autoRestartAction');


### PR DESCRIPTION
This pull request includes a single change to the `V202507101230__fix_completed_state_transitions.sql` migration file. It adds a new entry to the `fsm_transitions` table to handle a specific state transition for the `lodging_request` campaign.

* [`backend/database/migrations/V202507101230__fix_completed_state_transitions.sql`](diffhunk://#diff-094a8d58c5f0026d2014a4bde2008c456a2b7ab56c8f763e63ba496fa4cf0885R1-R2): Added a transition from the `COMPLETED` state to the `START` state triggered by `FIRSTCHATOPEN`, with the action `autoRestartAction`.