### PR TITLE
bugfix(NO-TICKET): fetch request by senior fix:

### DIFF
--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/spec/SeniorRequestSpecs.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/spec/SeniorRequestSpecs.java
@@ -32,17 +32,21 @@ public class SeniorRequestSpecs {
                         :cb.equal(root.get("status"), status);
     }
     public static Specification<SeniorRequest> hasSeniorId(Long seniorId) {
-        return (root, query, cb) ->
-                seniorId == null
-                        ? cb.conjunction()
-                        : cb.equal(root.get("senior").get("id"), seniorId);
+    // NOTE: SeniorRequest stores the foreign key as a scalar field "seniorId" (Long) – there is
+    // no JPA association named "senior". Attempting root.get("senior").get("id") caused
+    // PathElementException: Could not resolve attribute 'senior'. Use the scalar column instead.
+    return (root, query, cb) ->
+        seniorId == null
+            ? cb.conjunction()
+            : cb.equal(root.get("seniorId"), seniorId);
     }
 
     public static Specification<SeniorRequest> hasAssignedStaffId(Long staffId) {
-        return (root, query, cb) ->
-                staffId == null
-                        ? cb.conjunction()
-                        : cb.equal(root.get("assignedStaff").get("id"), staffId);
+    // Same reasoning as hasSeniorId: field is stored as scalar "assignedStaffId"
+    return (root, query, cb) ->
+        staffId == null
+            ? cb.conjunction()
+            : cb.equal(root.get("assignedStaffId"), staffId);
     }
 
     public static Specification<SeniorRequest> hasRequestTypeId(Long requestTypeId) {


### PR DESCRIPTION
Bug: `SeniorRequestSpecs` were navigating a nonexistent path root.get("senior").get("id") and root.get("assignedStaff").get("id"), triggering PathElementException.

Fix:
- Updated SeniorRequestSpecs.hasSeniorId to use root.get("seniorId")
- Updated SeniorRequestSpecs.hasAssignedStaffId to use root.get("assignedStaffId")