### PR TITLE
ORA-61 Cognito createStaff bug fix

### DIFF
--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/staffmanagement/service/CognitoService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/staffmanagement/service/CognitoService.java
@@ -70,7 +70,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to create Cognito user {}: {}", username, e.getMessage());
-            return Optional.empty();
+            throw new RuntimeException("Failed to create user in Cognito", e);
         }
     }
 
@@ -89,7 +89,7 @@ public class CognitoService {
             return Optional.empty();
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to get Cognito user {}: {}", username, e.getMessage());
-            return Optional.empty();
+            throw new RuntimeException("Failed to retrieve user from Cognito", e);
         }
     }
 
@@ -115,7 +115,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to update attributes for Cognito user {}: {}", username, e.getMessage());
-            return false;
+            throw new RuntimeException("Failed to update user attributes in Cognito", e);
         }
     }
 
@@ -137,7 +137,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to remove user {} from group {}: {}", usernameOrEmail, groupName, e.getMessage());
-            return false;
+            throw new RuntimeException("Failed to remove user from group in Cognito", e);
         }
     }
 
@@ -159,7 +159,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to add user {} to user group {}: {}", usernameOrEmail, groupName, e.getMessage());
-            return false;
+            throw new RuntimeException("Failed to add user to group in Cognito", e);
         }
     }
 
@@ -179,7 +179,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to set password for user {}: {}", username, e.getMessage());
-            return false;
+            throw new RuntimeException("Failed to set user password in Cognito", e);
         }
     }
 
@@ -202,7 +202,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to disable user {}: {}", username, e.getMessage());
-            return false;
+            throw new RuntimeException("Failed to disable user in Cognito", e);
         }
     }
 
@@ -236,7 +236,7 @@ public class CognitoService {
 
         } catch (CognitoIdentityProviderException e) {
             log.error("Failed to list users in group {}: {}", groupName, e.getMessage());
-            return List.of();
+            throw new RuntimeException("Failed to list users in group in Cognito", e);
         }
     }
 }


### PR DESCRIPTION
This pull request makes several important changes to how errors are handled in the Cognito integration and improves the sanitization of usernames when creating staff users. The main focus is on making error handling more robust and explicit by throwing exceptions instead of returning fallback values, and on ensuring generated usernames are valid and non-empty after sanitization. Additionally, there is a minor update regarding attribute updates and logging in staff creation.

**Error handling improvements in `CognitoService`:**

* Changed all methods in `CognitoService.java` to throw a `RuntimeException` with a descriptive message when a `CognitoIdentityProviderException` occurs, instead of returning fallback values like `Optional.empty()`, `false`, or an empty list. This ensures that errors are not silently ignored and can be handled appropriately by higher layers. [[1]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL73-R73) [[2]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL92-R92) [[3]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL118-R118) [[4]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL140-R140) [[5]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL162-R162) [[6]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL182-R182) [[7]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL205-R205) [[8]](diffhunk://#diff-94af52ec3916086de4ff782c2c15b961b3f99a46ddf8db5ca35c3c19a38b805bL239-R239)

**Username sanitization in staff creation:**

* Updated username generation in `StaffManagementService.java` to replace whitespace with underscores and remove invalid characters using a regex, ensuring the username is valid for Cognito. Added a check to throw an exception if the sanitized username is empty.

**Staff creation and logging:**

* Removed the immediate update of Cognito user attributes with the staff database ID after staff creation, and updated the logging to prompt for cleanup implementation if user creation fails.- add cognitoUsername sanitisation logic