### PR TITLE
ORA-89 Change license to MIT + common clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,22 @@
+“Commons Clause” License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: SeniorSync Care Management System
+
+License: MIT
+
+Licensor: SeniorSync
+
+------------------------------------------------------
+
 MIT License
 
-Copyright (c) 2025 BFGOrangle
+Copyright (c) 2025 SeniorSync
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the `LICENSE` file to add the “Commons Clause” License Condition v1.0 to the existing MIT License. This addition restricts the rights granted under the MIT License by prohibiting the sale of the software or services that derive substantial value from its functionality.

Most important change:

* Licensing update:
  * Added the “Commons Clause” License Condition v1.0 to the `LICENSE` file, restricting the right to sell the software and clarifying the definition of "Sell" in the context of the license. The copyright holder and software name were also updated.