### PR TITLE
chore(NO-TICKET): vendor app endpoint

### DIFF
--- a/backend/seniorsync/src/main/java/orangle/seniorsync/common/config/SecurityConfig.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/common/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Allow preflight requests
                         .requestMatchers("/api/auth/**").permitAll() // Public auth endpoints
                         .requestMatchers("/api/test/**").permitAll() // Test endpoints
+                        .requestMatchers("/api/vendor-applications").permitAll()
                         .requestMatchers("/swagger", "/swagger-ui/**", "/api-docs/**").permitAll() // Swagger UI
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
- fix vendor application endpoint to allow all (no need auth bearer token)