### PR TITLE
ORA-102 Make Cognito tokens more short-lived for better security

### DIFF
--- a/terraform/global/cognito/cognito.tf
+++ b/terraform/global/cognito/cognito.tf
@@ -115,14 +115,14 @@ resource "aws_cognito_user_pool_client" "client" {
     "ALLOW_CUSTOM_AUTH"
   ]
 
-  # Enable MFA settings for the client - shorter token lifetimes for security
-  access_token_validity = 2
-  id_token_validity = 2
-  refresh_token_validity = 7
+  # Token validity settings optimized for security
+  access_token_validity = 30
+  id_token_validity = 30
+  refresh_token_validity = 1
 
   token_validity_units {
-    access_token  = "hours"
-    id_token      = "hours"
+    access_token  = "minutes"
+    id_token      = "minutes" 
     refresh_token = "days"
   }
 


### PR DESCRIPTION
This pull request updates the token validity settings for the Cognito user pool client to improve security and better align with best practices. The most important change is switching the access and ID token validity from hours to minutes, and adjusting their durations accordingly.

Token validity configuration updates:

* Increased `access_token_validity` and `id_token_validity` from 2 hours to 30 minutes, and changed their units from hours to minutes in `aws_cognito_user_pool_client.client` in `cognito.tf`.
* Reduced `refresh_token_validity` from 7 days to 1 day for shorter refresh token lifetimes.