### PR TITLE
ORA-113 Request Types creation/deletion + Allow editing or request type in request page

### DIFF
--- a/backend/database/migrations/V202508282258__add_center_id_to_request_types_table.sql
+++ b/backend/database/migrations/V202508282258__add_center_id_to_request_types_table.sql
@@ -1,0 +1,9 @@
+ALTER TABLE senior_sync.request_types 
+ADD COLUMN is_global BOOLEAN DEFAULT FALSE;
+
+UPDATE senior_sync.request_types
+SET is_global = TRUE
+WHERE is_global = FALSE;  -- all existing rows were created before column, now flip to TRUE
+
+ALTER TABLE senior_sync.request_types 
+ADD COLUMN center_id BIGINT REFERENCES senior_sync.centers(id);

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/controller/RequestTypeController.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/controller/RequestTypeController.java
@@ -1,0 +1,39 @@
+package orangle.seniorsync.crm.requestmanagement.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import orangle.seniorsync.crm.requestmanagement.dto.CreateRequestTypeDto;
+import orangle.seniorsync.crm.requestmanagement.dto.RequestTypeDto;
+import orangle.seniorsync.crm.requestmanagement.service.IRequestTypeService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/request-types")
+@PreAuthorize("hasRole('ADMIN') or hasRole('STAFF')")
+@RequiredArgsConstructor
+public class RequestTypeController {
+
+    private final IRequestTypeService requestTypeService;
+
+    @GetMapping("/all/center/{centerId}")
+    public List<RequestTypeDto> getAllRequestTypesByCenterId(@PathVariable Long centerId) {
+        return requestTypeService.getAllRequestTypesByCenterId(centerId).stream()
+                .map(rt -> new RequestTypeDto(rt.getId(), rt.getName(), rt.getDescription(), rt.getIsGlobal(), rt.getCenterId()))
+                .toList();
+    }
+
+    @PostMapping
+    public CreateRequestTypeDto createRequestTypeIfNotExist(@Validated @RequestBody CreateRequestTypeDto createRequestTypeDto) {
+        return requestTypeService.createDefaultRequestTypesIfNotExist(createRequestTypeDto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteRequestTypeById(@PathVariable Long id) {
+        requestTypeService.deleteRequestTypeById(id);
+    }
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/dto/CreateRequestTypeDto.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/dto/CreateRequestTypeDto.java
@@ -1,0 +1,16 @@
+package orangle.seniorsync.crm.requestmanagement.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record CreateRequestTypeDto (
+    @NotEmpty
+    String name,
+    @NotEmpty
+    String description,
+
+    @NotNull
+    Long centerId
+) {}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/dto/RequestTypeDto.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/dto/RequestTypeDto.java
@@ -1,0 +1,9 @@
+package orangle.seniorsync.crm.requestmanagement.dto;
+
+public record RequestTypeDto(
+    Long id,
+    String name,
+    String description,
+    Boolean isGlobal,
+    Long centerId
+) {}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/model/RequestType.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/model/RequestType.java
@@ -22,4 +22,10 @@ public class RequestType {
     @Column(name = "description", length = Integer.MAX_VALUE)
     private String description;
 
+    @Column(name = "is_global")
+    private Boolean isGlobal = Boolean.FALSE;
+
+    @Column(name = "center_id")
+    private Long centerId;
+
 }

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/service/IRequestTypeService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/service/IRequestTypeService.java
@@ -1,0 +1,12 @@
+package orangle.seniorsync.crm.requestmanagement.service;
+
+import orangle.seniorsync.crm.requestmanagement.dto.CreateRequestTypeDto;
+import orangle.seniorsync.crm.requestmanagement.model.RequestType;
+
+import java.util.List;
+
+public interface IRequestTypeService {
+    List<RequestType> getAllRequestTypesByCenterId(Long centerId);
+    CreateRequestTypeDto createDefaultRequestTypesIfNotExist(CreateRequestTypeDto requestTypeDto);
+    void deleteRequestTypeById(Long id);
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/service/RequestTypeService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/requestmanagement/service/RequestTypeService.java
@@ -1,0 +1,44 @@
+package orangle.seniorsync.crm.requestmanagement.service;
+
+import lombok.RequiredArgsConstructor;
+import orangle.seniorsync.crm.requestmanagement.dto.CreateRequestTypeDto;
+import orangle.seniorsync.crm.requestmanagement.model.RequestType;
+import orangle.seniorsync.crm.requestmanagement.repository.RequestTypeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RequestTypeService implements IRequestTypeService {
+
+    private final RequestTypeRepository requestTypeRepository;
+
+    @Override
+    public List<RequestType> getAllRequestTypesByCenterId(Long centerId) {
+        return requestTypeRepository.findAll().stream()
+                .filter(rt -> centerId.equals(rt.getCenterId()) || rt.getIsGlobal())
+                .toList();
+    }
+
+    @Override
+    public CreateRequestTypeDto createDefaultRequestTypesIfNotExist(CreateRequestTypeDto requestTypeDto) {
+        boolean exists = requestTypeRepository.findAll().stream()
+                .anyMatch(rt -> rt.getName().equals(requestTypeDto.name()) && rt.getCenterId().equals(requestTypeDto.centerId()));
+        if (!exists) {
+            var requestType = new orangle.seniorsync.crm.requestmanagement.model.RequestType();
+            requestType.setName(requestTypeDto.name());
+            requestType.setDescription(requestTypeDto.description());
+            requestType.setCenterId(requestTypeDto.centerId());
+            requestTypeRepository.save(requestType);
+        } else {
+            throw new RuntimeException("Request type already exists");
+        }
+        return requestTypeDto;
+    }
+
+    @Override
+    public void deleteRequestTypeById(Long id) {
+        requestTypeRepository.deleteById(id);
+    }
+}

--- a/crm-ui/src/app/(admin)/admin/request-management/request-types/page.tsx
+++ b/crm-ui/src/app/(admin)/admin/request-management/request-types/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { requestTypeApiService, RequestTypeDto } from '@/services/request-type-api';
+import { staffApiService } from '@/services/staff-api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Loader2, Trash2, PlusCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+interface RequestTypeRow { id?: number; name: string; description?: string | null }
+
+export default function AdminRequestTypesPage() {
+  const [centerId, setCenterId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [types, setTypes] = useState<RequestTypeRow[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [newDescription, setNewDescription] = useState('');
+  const { toast } = useToast();
+
+  const load = async (cid: number) => {
+    setLoading(true);
+    try {
+  const list: RequestTypeDto[] = await requestTypeApiService.getAllByCenter(cid);
+  // Exclude global types from admin center-scoped management view
+  const centerOnly = list.filter(rt => !rt.isGlobal);
+  setTypes(centerOnly.map(rt => ({ id: rt.id, name: rt.name, description: rt.description })));
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Error', description: 'Failed to load request types', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const profile = await staffApiService.getCurrentUserProfile();
+        if (profile?.centerId) {
+          setCenterId(profile.centerId);
+          await load(profile.centerId);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
+
+  const createType = async () => {
+    if (!centerId || !newName.trim() || !newDescription.trim()) return;
+    setCreating(true);
+    try {
+      await requestTypeApiService.create({ name: newName.trim(), description: newDescription.trim(), centerId });
+      setNewName('');
+      setNewDescription('');
+      await load(centerId);
+      toast({ title: 'Created', description: 'Request type added' });
+    } catch (e) {
+      toast({ title: 'Error', description: 'Failed to create type', variant: 'destructive' });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const deleteType = async (id: number | undefined, name: string) => {
+    if (!id) { 
+      toast({ title: 'Cannot delete', description: 'ID not available from API list', variant: 'destructive' });
+      return;
+    }
+    if (!centerId) return;
+    setDeletingId(id);
+    try {
+      await requestTypeApiService.delete(id);
+      await load(centerId);
+      toast({ title: 'Deleted', description: `Removed ${name}` });
+    } catch (e: any) {
+      // Assume failure likely due to FK constraint (in-use). Provide specific guidance.
+      const status = e?.response?.status || e?.status;
+      const baseMsg = 'Other senior requests are already using this type, so it cannot be deleted.';
+      toast({
+        title: 'Cannot delete',
+        description: status === 409 ? baseMsg : baseMsg + ' If you believe this is an error, remove or reassign those requests first.',
+        variant: 'destructive'
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Request Types</CardTitle>
+          <CardDescription>Manage custom request types for your center only. Global types (if any) are not shown here.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2 border rounded-md p-4 bg-muted/40">
+            <div className="flex gap-2">
+              <Input placeholder="New request type name *" value={newName} onChange={e => setNewName(e.target.value)} disabled={!centerId || creating} />
+              <Button onClick={createType} disabled={!newName.trim() || !newDescription.trim() || !centerId || creating} variant="outline">
+                {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlusCircle className="h-4 w-4" />}
+              </Button>
+            </div>
+            <Textarea placeholder="Description (required)" value={newDescription} onChange={e => setNewDescription(e.target.value)} disabled={!centerId || creating} className="min-h-[70px]" />
+            <p className="text-[11px] text-muted-foreground">Provide a clear name and description. These are center-scoped.</p>
+          </div>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading...</div>
+          ) : types.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No request types yet. Add one above.</p>
+          ) : (
+            <ul className="divide-y border rounded-md">
+              {types.map((t, idx) => (
+                <li key={idx} className="px-3 py-2 text-sm flex flex-col gap-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">{t.name}</span>
+                    <Button disabled={!t.id || deletingId === t.id} size="icon" variant="ghost" onClick={() => deleteType(t.id, t.name)}>
+                      {deletingId === t.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                    </Button>
+                  </div>
+                  {t.description && <p className="text-xs text-muted-foreground leading-snug line-clamp-3">{t.description}</p>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/crm-ui/src/app/(staff)/staff/request-management/request-types/page.tsx
+++ b/crm-ui/src/app/(staff)/staff/request-management/request-types/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { requestTypeApiService, RequestTypeDto } from '@/services/request-type-api';
+import { staffApiService } from '@/services/staff-api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Loader2, PlusCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+interface RequestTypeRow { id?: number; name: string; description?: string | null }
+
+export default function StaffRequestTypesPage() {
+  const [centerId, setCenterId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [types, setTypes] = useState<RequestTypeRow[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newDescription, setNewDescription] = useState('');
+  const [newName, setNewName] = useState('');
+  const { toast } = useToast();
+
+  const load = async (cid: number) => {
+    setLoading(true);
+    try {
+  const list: RequestTypeDto[] = await requestTypeApiService.getAllByCenter(cid);
+  setTypes(list.map(rt => ({ id: rt.id, name: rt.name, description: rt.description })));
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Error', description: 'Failed to load request types', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const profile = await staffApiService.getCurrentUserProfile();
+        if (profile?.centerId) {
+          setCenterId(profile.centerId);
+          await load(profile.centerId);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
+
+  const createType = async () => {
+    if (!centerId || !newName.trim() || !newDescription.trim()) return;
+    setCreating(true);
+    try {
+      await requestTypeApiService.create({ name: newName.trim(), description: newDescription.trim(), centerId });
+      setNewName('');
+      setNewDescription('');
+      await load(centerId);
+      toast({ title: 'Created', description: 'Request type added' });
+    } catch (e) {
+      toast({ title: 'Error', description: 'Failed to create type', variant: 'destructive' });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Request Types</CardTitle>
+          <CardDescription>Create request types for your center. Deletion limited to administrators.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2 border rounded-md p-4 bg-muted/40">
+            <div className="flex gap-2">
+              <Input placeholder="New request type name *" value={newName} onChange={e => setNewName(e.target.value)} disabled={!centerId || creating} />
+              <Button onClick={createType} disabled={!newName.trim() || !newDescription.trim() || !centerId || creating} variant="outline">
+                {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlusCircle className="h-4 w-4" />}
+              </Button>
+            </div>
+            <Textarea placeholder="Description (required)" value={newDescription} onChange={e => setNewDescription(e.target.value)} disabled={!centerId || creating} className="min-h-[70px]" />
+            <p className="text-[11px] text-muted-foreground">Provide a clear, concise name and description. These are center-scoped.</p>
+          </div>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading...</div>
+          ) : types.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No request types yet. Add one above.</p>
+          ) : (
+            <ul className="divide-y border rounded-md">
+              {types.map((t, idx) => (
+                <li key={idx} className="px-3 py-2 text-sm flex flex-col gap-1">
+                  <span className="font-medium">{t.name}</span>
+                  {t.description && <p className="text-xs text-muted-foreground leading-snug line-clamp-3">{t.description}</p>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/crm-ui/src/components/admin-sidebar.tsx
+++ b/crm-ui/src/components/admin-sidebar.tsx
@@ -56,6 +56,12 @@ const overviewItems = [
         url: "/admin/request-management/ai-recommendations",
         icon: Sparkles,
       }
+      ,
+      {
+        title: "Request Types",
+        url: "/admin/request-management/request-types",
+        icon: ClipboardList,
+      }
     ]
   },
 

--- a/crm-ui/src/components/request-details-page.tsx
+++ b/crm-ui/src/components/request-details-page.tsx
@@ -51,6 +51,7 @@ import { SpamIndicatorBadge } from "@/components/spam-indicator-badge";
 import { ErrorMessageCallout } from "@/components/error-message-callout";
 import { Calendar } from "lucide-react";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { RequestTypeSelectWithCreate } from "@/components/request-type-selector";
 
 type Priority = "low" | "medium" | "high" | "urgent";
 type Status = "todo" | "in-progress" | "completed";
@@ -479,9 +480,32 @@ export function RequestDetailsPage({ requestId }: RequestDetailsPageProps) {
 
               <div className="space-y-2">
                 <Label htmlFor="requestType">Request Type</Label>
-                <Badge variant="secondary" className="px-2">
-                  {editedRequest.requestTypeName || "N/A"}
-                </Badge>
+                {isEditing && canEdit ? (
+                  <div className="space-y-1">
+                    <RequestTypeSelectWithCreate
+                      value={editedRequest.requestTypeId}
+                      onChange={(id, meta) => {
+                        setEditedRequest({
+                          ...editedRequest,
+                          requestTypeId: id,
+                          requestTypeName: meta?.name || editedRequest.requestTypeName
+                        });
+                      }}
+                    />
+                    {editedRequest.requestTypeDescription && (
+                      <p className="text-xs text-muted-foreground leading-snug">{editedRequest.requestTypeDescription}</p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    <Badge variant="secondary" className="px-2">
+                      {editedRequest.requestTypeName || "N/A"}
+                    </Badge>
+                    {editedRequest.requestTypeDescription && (
+                      <p className="text-xs text-muted-foreground leading-snug">{editedRequest.requestTypeDescription}</p>
+                    )}
+                  </div>
+                )}
               </div>
 
               <div className="space-y-2 md:col-span-2">

--- a/crm-ui/src/components/request-type-selector.tsx
+++ b/crm-ui/src/components/request-type-selector.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Loader2, PlusCircle } from 'lucide-react';
+import { SearchableSelect } from '@/components/ui/searchable-select';
+import { requestTypeApiService, RequestTypeDto } from '@/services/request-type-api';
+import { staffApiService } from '@/services/staff-api';
+import { useToast } from '@/hooks/use-toast';
+
+interface RequestTypeSelectWithCreateProps {
+  value?: number;
+  onChange: (id: number | undefined, meta?: { name?: string; description?: string }) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  centerId?: number; // optional override
+  allowCreate?: boolean;
+  className?: string;
+}
+
+export function RequestTypeSelectWithCreate({
+  value,
+  onChange,
+  disabled,
+  placeholder = 'Select request type...',
+  centerId: centerIdProp,
+  allowCreate = true,
+  className,
+}: RequestTypeSelectWithCreateProps) {
+  const { toast } = useToast();
+  const [centerId, setCenterId] = useState<number | null>(centerIdProp ?? null);
+  const [requestTypes, setRequestTypes] = useState<RequestTypeDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  const load = useCallback(async (cid: number) => {
+    setLoading(true);
+    try {
+      const list = await requestTypeApiService.getAllByCenter(cid);
+      setRequestTypes(list);
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Error', description: 'Failed to load request types', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  // Resolve centerId if not provided
+  useEffect(() => {
+    if (centerIdProp) {
+      setCenterId(centerIdProp);
+      load(centerIdProp);
+      return;
+    }
+    (async () => {
+      try {
+        const profile = await staffApiService.getCurrentUserProfile();
+        if (profile?.centerId) {
+          setCenterId(profile.centerId);
+          load(profile.centerId);
+        }
+      } catch (e) {
+        console.error('Failed to fetch staff profile for centerId', e);
+      }
+    })();
+  }, [centerIdProp, load]);
+
+  const handleCreate = async () => {
+    if (!centerId || !newName.trim() || !newDescription.trim()) return;
+    setCreating(true);
+    try {
+      await requestTypeApiService.create({ name: newName.trim(), description: newDescription.trim(), centerId });
+      toast({ title: 'Added', description: 'Request type created for your center.' });
+      setNewName('');
+      setNewDescription('');
+      await load(centerId);
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Error', description: 'Failed to create request type.', variant: 'destructive' });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className={className}>      
+      <div className="space-y-2">
+        <SearchableSelect
+          options={requestTypes.map(rt => ({
+            value: rt.id.toString(),
+            label: rt.name,
+            subtitle: rt.description || undefined,
+          }))}
+          value={value?.toString()}
+          onValueChange={(val) => {
+            const id = val ? parseInt(val) : undefined;
+            const rt = requestTypes.find(r => r.id === id);
+            onChange(id, { name: rt?.name, description: (rt?.description ?? undefined) });
+          }}
+          placeholder={loading ? 'Loading request types...' : placeholder}
+          searchPlaceholder="Search request types..."
+          emptyMessage={allowCreate ? 'No request types found. Create one below.' : 'No request types.'}
+          disabled={disabled || loading}
+        />
+
+        {allowCreate && !showCreateForm && (
+          <div className="pt-1">
+            <Button type="button" size="sm" variant="ghost" disabled={!centerId || loading} onClick={() => setShowCreateForm(true)}>
+              <PlusCircle className="h-4 w-4 mr-1" /> Create new request type
+            </Button>
+          </div>
+        )}
+        {allowCreate && showCreateForm && (
+          <div className="space-y-2 border rounded-md p-3 bg-muted/30">
+            <div className="flex items-center gap-2">
+              <Input
+                placeholder="New request type name *"
+                value={newName}
+                disabled={!centerId || creating}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!newName.trim() || !newDescription.trim() || !centerId || creating}
+                  onClick={handleCreate}
+                >
+                  {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlusCircle className="h-4 w-4" />}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={creating}
+                  onClick={() => { setShowCreateForm(false); setNewName(''); setNewDescription(''); }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+            <Textarea
+              placeholder="Short description (purpose, example) *"
+              value={newDescription}
+              disabled={!centerId || creating}
+              onChange={(e) => setNewDescription(e.target.value)}
+              className="min-h-[70px]"
+            />
+            <p className="text-[11px] text-muted-foreground">Both name and description are required. Created types are scoped to your center.</p>
+          </div>
+        )}
+        {!centerId && (
+          <p className="text-xs text-muted-foreground">Center not detected; cannot add new request types.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crm-ui/src/components/staff-sidebar.tsx
+++ b/crm-ui/src/components/staff-sidebar.tsx
@@ -52,6 +52,12 @@ const overviewItems = [
         url: "/staff/request-management/ai-recommendations",
         icon: Sparkles,
       }
+      ,
+      {
+        title: "Request Types",
+        url: "/staff/request-management/request-types",
+        icon: ClipboardList,
+      }
     ]
   },
   {

--- a/crm-ui/src/components/ui/searchable-select.tsx
+++ b/crm-ui/src/components/ui/searchable-select.tsx
@@ -129,11 +129,7 @@ export function SearchableSelect({
           }
         }}
       >
-        <div 
-          className="p-2" 
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
-        >
+  <div className="p-2" onClick={(e) => e.stopPropagation()}>
           <Input
             placeholder={searchPlaceholder}
             value={search}
@@ -143,15 +139,13 @@ export function SearchableSelect({
             autoFocus
             onMouseDown={(e) => e.stopPropagation()}
           />
-          <div 
+          <div
             className="max-h-60 overflow-y-auto overscroll-contain"
-            onMouseDown={(e) => e.stopPropagation()}
+            // Allow natural mouse wheel & scrollbar interactions
+            onWheel={(e) => e.stopPropagation()}
           >
             {filteredOptions.length > 0 ? (
-              <div 
-                className="space-y-1 p-1"
-                onMouseDown={(e) => e.stopPropagation()}
-              >
+              <div className="space-y-1 p-1">
                 {filteredOptions.map((option) => (
                   <div
                     key={option.value}
@@ -162,12 +156,13 @@ export function SearchableSelect({
                     )}
                     onClick={(e) => {
                       e.preventDefault();
+                      // stopPropagation to avoid closing before selection logic runs
                       e.stopPropagation();
                       if (!option.disabled) {
                         handleSelect(option.value);
                       }
                     }}
-                    onMouseDown={(e) => e.preventDefault()}
+                    // Don't prevent default on mousedown so scrollbar & wheel work naturally
                   >
                     <Check
                       className={cn(

--- a/crm-ui/src/hooks/use-requests.ts
+++ b/crm-ui/src/hooks/use-requests.ts
@@ -218,6 +218,7 @@ export function useRequestManagement() {
                 seniorAddress: updatedRequest.seniorAddress,
                 assignedStaffName: assignedStaffName,
                 requestTypeName: updatedRequest.requestTypeName,
+                requestTypeDescription: updatedRequest.requestTypeDescription,
               })
             : request
         )
@@ -567,7 +568,8 @@ export function useRequest(requestId: number | null) {
         seniorEmail: updatedRequest.seniorEmail,
         seniorAddress: updatedRequest.seniorAddress,
         assignedStaffName: assignedStaffName,
-        requestTypeName: updatedRequest.requestTypeName,
+  requestTypeName: updatedRequest.requestTypeName,
+  requestTypeDescription: updatedRequest.requestTypeDescription,
       });
 
       setRequest(enhancedUpdated);

--- a/crm-ui/src/services/request-type-api.ts
+++ b/crm-ui/src/services/request-type-api.ts
@@ -1,0 +1,39 @@
+import { AuthenticatedApiClient } from './authenticated-api-client';
+
+// Types
+export interface RequestTypeDto {
+  id: number;
+  name: string;
+  description?: string | null;
+  isGlobal?: boolean | null;
+  centerId?: number | null;
+}
+
+export interface CreateRequestTypeDto {
+  name: string;
+  description?: string | null;
+  centerId?: number | null; // Backend will treat absence as global or attach automatically based on user context
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8088';
+const REQUEST_TYPE_ENDPOINT = `${API_BASE_URL}/api/request-types`;
+
+class RequestTypeApiClient extends AuthenticatedApiClient {}
+
+export class RequestTypeApiService {
+  private client = new RequestTypeApiClient();
+
+  async getAllByCenter(centerId: number): Promise<RequestTypeDto[]> {
+    return this.client.get<RequestTypeDto[]>(`${REQUEST_TYPE_ENDPOINT}/all/center/${centerId}`);
+  }
+
+  async create(dto: CreateRequestTypeDto): Promise<CreateRequestTypeDto> {
+    return this.client.post<CreateRequestTypeDto>(REQUEST_TYPE_ENDPOINT, dto);
+  }
+
+  async delete(id: number): Promise<void> {
+    return this.client.delete<void>(`${REQUEST_TYPE_ENDPOINT}/${id}`);
+  }
+}
+
+export const requestTypeApiService = new RequestTypeApiService();

--- a/crm-ui/src/types/request.ts
+++ b/crm-ui/src/types/request.ts
@@ -104,6 +104,7 @@ export interface SeniorRequestDisplayView extends SeniorRequestView {
 
   // Additional request type information
   requestTypeName?: string;
+  requestTypeDescription?: string;
 
   // Frontend compatibility fields (computed from backend data)
   frontendStatus: "todo" | "in-progress" | "completed";
@@ -191,6 +192,7 @@ export const RequestUtils = {
       seniorAddress?: string;
       assignedStaffName?: string;
       requestTypeName?: string;
+  requestTypeDescription?: string;
     }
   ): SeniorRequestDisplayView {
     return {
@@ -211,6 +213,7 @@ export const RequestUtils = {
       seniorAddress?: string;
       assignedStaffName?: string;
       requestTypeName?: string;
+  requestTypeDescription?: string;
     }
   ): SeniorRequestDisplayView {
     return {


### PR DESCRIPTION
This pull request introduces center-scoped request types to the SeniorSync application, allowing both staff and admins to manage custom request types per center instead of relying on a hardcoded global list. It includes backend database and API changes, as well as new frontend pages for managing request types. The main changes are grouped below.

**Backend: Request Type Model and API Enhancements**

* Added `is_global` and `center_id` columns to the `request_types` table, updated all existing rows to be global, and established a foreign key relationship to `centers` (`V202508282258__add_center_id_to_request_types_table.sql`).
* Updated the `RequestType` entity to include `isGlobal` and `centerId` fields.
* Introduced DTOs for request type creation and retrieval (`CreateRequestTypeDto`, `RequestTypeDto`). [[1]](diffhunk://#diff-ac288f90ab21f3bc95eee2e01c7c5a577137a40dff4d892e003e5394ce07f463R1-R16) [[2]](diffhunk://#diff-2e17919f57dad83c5c34247aaac3eca18ce96a8f1dcab522d658aa9df6974effR1-R9)
* Implemented `IRequestTypeService` and its service layer, providing methods to create, fetch (by center), and delete request types, with logic to prevent duplicates. [[1]](diffhunk://#diff-2ea83b002f9b267ee7d829c01dd18becf271c8e49f2dff82fbef349ba9edc856R1-R12) [[2]](diffhunk://#diff-de29cc55e9647fa2517c13c4fb6a5b40daf5a34afa1a6fe4adbd74a6e81d6966R1-R44)
* Added a new `RequestTypeController` exposing endpoints for CRUD operations, secured for admin/staff roles.

**Frontend: Center-Scoped Request Types Management**

* Added new admin and staff pages for managing request types per center, enabling creation (both) and deletion (admin only), and filtering out global types in the admin view. [[1]](diffhunk://#diff-411e5ab014a5fbd4295056aad07d71d5875cc791fde981f550340a7d3716e9d5R1-R136) [[2]](diffhunk://#diff-7baefaeff1d5be4ad528e49b6794df61306796e725230681515c9e7e3995361eR1-R103)
* Updated the admin sidebar to include a link to the new Request Types management page.
* Refactored the request creation modal to dynamically fetch request types per center from the backend, replacing the previous hardcoded list. [[1]](diffhunk://#diff-ae49a0ca985febbcfa2ef10a6cc25fdefd942477a431ad424bb985715c688cdaL35-R46) [[2]](diffhunk://#diff-ae49a0ca985febbcfa2ef10a6cc25fdefd942477a431ad424bb985715c688cdaR84-R88) [[3]](diffhunk://#diff-ae49a0ca985febbcfa2ef10a6cc25fdefd942477a431ad424bb985715c688cdaR115-R121) [[4]](diffhunk://#diff-ae49a0ca985febbcfa2ef10a6cc25fdefd942477a431ad424bb985715c688cdaR134-R150)

These changes make request type management more flexible and scalable, allowing each center to customize its available request types while maintaining global options where needed.…pe in request page