### PR TITLE
feat(ORA-119): change reminder job to use quartz instead of batch job

### DIFF
--- a/backend/seniorsync/pom.xml
+++ b/backend/seniorsync/pom.xml
@@ -90,6 +90,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-quartz</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/config/AutowiringSpringBeanJobFactory.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/config/AutowiringSpringBeanJobFactory.java
@@ -1,0 +1,24 @@
+package orangle.seniorsync.crm.reminder.config;
+
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+
+public final class AutowiringSpringBeanJobFactory extends SpringBeanJobFactory implements ApplicationContextAware {
+
+    private transient AutowireCapableBeanFactory beanFactory;
+
+    @Override
+    public void setApplicationContext(final ApplicationContext context) {
+        beanFactory = context.getAutowireCapableBeanFactory();
+    }
+
+    @Override
+    protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
+        final Object job = super.createJobInstance(bundle);
+        beanFactory.autowireBean(job);
+        return job;
+    }
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/config/QuartzConfig.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/config/QuartzConfig.java
@@ -1,0 +1,22 @@
+package orangle.seniorsync.crm.reminder.config;
+
+import org.quartz.Scheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+@Configuration
+public class QuartzConfig {
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean() {
+        SchedulerFactoryBean schedulerFactoryBean = new SchedulerFactoryBean();
+        schedulerFactoryBean.setJobFactory(new AutowiringSpringBeanJobFactory());
+        return schedulerFactoryBean;
+    }
+
+    @Bean
+    public Scheduler scheduler(SchedulerFactoryBean schedulerFactoryBean) {
+        return schedulerFactoryBean.getScheduler();
+    }
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/job/ReminderJob.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/job/ReminderJob.java
@@ -1,0 +1,33 @@
+package orangle.seniorsync.crm.reminder.job;
+
+import lombok.extern.slf4j.Slf4j;
+import orangle.seniorsync.crm.reminder.service.ReminderService;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ReminderJob implements Job {
+
+    @Autowired
+    private ReminderService reminderService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        JobDataMap dataMap = context.getJobDetail().getJobDataMap();
+        Long reminderId = dataMap.getLong("reminderId");
+        
+        log.info("Executing reminder job for reminder ID: {}", reminderId);
+        
+        try {
+            reminderService.sendReminderById(reminderId);
+        } catch (Exception e) {
+            log.error("Failed to send reminder for ID: {}", reminderId, e);
+            throw new JobExecutionException(e);
+        }
+    }
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/repository/ReminderRepository.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/repository/ReminderRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface ReminderRepository extends JpaRepository<Reminder, Long> {
     List<Reminder> findByRequestId(Long requestId);
     List<Reminder> findByReminderDateBetween(OffsetDateTime start, OffsetDateTime end);
+    List<Reminder> findByReminderDateAfter(OffsetDateTime dateTime);
 }

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/DailyReminderService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/DailyReminderService.java
@@ -1,56 +1,47 @@
 package orangle.seniorsync.crm.reminder.service;
 
 import lombok.extern.slf4j.Slf4j;
-import orangle.seniorsync.crm.staffmanagement.model.Staff;
-import orangle.seniorsync.crm.staffmanagement.repository.StaffRepository;
-import orangle.seniorsync.crm.reminder.model.Reminder;
 import orangle.seniorsync.crm.reminder.repository.ReminderRepository;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
-public class DailyReminderService implements IDailyReminderService{
-    private final IEmailService emailService;
+public class DailyReminderService {
+    
     private final ReminderRepository reminderRepository;
-    private final StaffRepository staffRepository;
+    private final QuartzReminderSchedulerService schedulerService;
 
-    public DailyReminderService(IEmailService emailService, ReminderRepository reminderRepository, StaffRepository staffRepository) {
-        this.emailService = emailService;
+    public DailyReminderService(ReminderRepository reminderRepository, 
+                               QuartzReminderSchedulerService schedulerService) {
         this.reminderRepository = reminderRepository;
-        this.staffRepository = staffRepository;
+        this.schedulerService = schedulerService;
     }
-    @Scheduled(cron = "0 0 8 * * ?") // Runs daily at 8:00 AM
-    public void sendDailyReminders() {
-        // Logic to send daily reminders
-        OffsetDateTime startOfDay = OffsetDateTime.now(java.time.ZoneId.of("Asia/Singapore"))
-            .toLocalDate()
-            .atStartOfDay(java.time.ZoneId.of("Asia/Singapore"))
-            .toOffsetDateTime();
-        OffsetDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
 
-        // Find reminders for the entire day
-        List<Reminder> remindersDueToday = reminderRepository.findByReminderDateBetween(startOfDay, endOfDay);
-        log.info("Found {} reminders due today", remindersDueToday.size());
-        for (Reminder reminder : remindersDueToday) {
-            // Send email notification for each reminder
-            /*
-            * function to get email by assignee staff id
-            * placeholder for now, assuming email is hardcoded
-            * */
-            String staffEmail = staffRepository.findById(reminder.getStaffAssigneeId())
-                    .map(Staff::getContactEmail)
-                    .orElse("");
-            if (staffEmail == null || staffEmail.isEmpty()) {
-                log.warn("No valid email found for staff assignee ID: {}. Skipping email for reminder ID: {}", 
-                        reminder.getStaffAssigneeId(), reminder.getId());
-                continue;
+    /**
+     * Re-schedule existing reminders on application startup.
+     * This ensures that reminders scheduled before application restart
+     * are properly rescheduled in Quartz.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void rescheduleExistingReminders() {
+        log.info("Rescheduling existing future reminders on application startup");
+        
+        var futureReminders = reminderRepository.findByReminderDateAfter(OffsetDateTime.now());
+        log.info("Found {} future reminders to reschedule", futureReminders.size());
+        
+        futureReminders.forEach(reminder -> {
+            if (!schedulerService.isReminderScheduled(reminder.getId())) {
+                schedulerService.scheduleReminder(reminder);
+                log.debug("Rescheduled reminder ID: {} for {}", reminder.getId(), reminder.getReminderDate());
+            } else {
+                log.debug("Reminder ID: {} is already scheduled", reminder.getId());
             }
-            emailService.sendEmail(staffEmail, reminder.getTitle(), reminder.getDescription());
-            log.info("Sent reminder email for reminder ID: {}", reminder.getId());
-        }
+        });
+        
+        log.info("Completed rescheduling existing reminders");
     }
 }

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/INotificationService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/INotificationService.java
@@ -49,4 +49,10 @@ public interface INotificationService {
      * @param previousStaffId The staff member who was previously assigned
      */
     void notifyRequestUnassignment(SeniorRequest request, Long previousStaffId);
+    
+    /**
+     * Send reminder notification when a scheduled reminder is triggered
+     * @param reminder The reminder to send notification for
+     */
+    void notifyReminderTriggered(Reminder reminder);
 }

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/QuartzReminderSchedulerService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/QuartzReminderSchedulerService.java
@@ -1,0 +1,87 @@
+package orangle.seniorsync.crm.reminder.service;
+
+import lombok.extern.slf4j.Slf4j;
+import orangle.seniorsync.crm.reminder.job.ReminderJob;
+import orangle.seniorsync.crm.reminder.model.Reminder;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+
+@Slf4j
+@Service
+public class QuartzReminderSchedulerService {
+    
+    private final Scheduler scheduler;
+
+    public QuartzReminderSchedulerService(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void scheduleReminder(Reminder reminder) {
+        try {
+            String jobName = "reminder-job-" + reminder.getId();
+            String groupName = "reminder-group";
+
+            JobDetail jobDetail = JobBuilder.newJob(ReminderJob.class)
+                    .withIdentity(jobName, groupName)
+                    .usingJobData("reminderId", reminder.getId())
+                    .build();
+
+            // Convert OffsetDateTime to Date for Quartz
+            Date triggerTime = Date.from(reminder.getReminderDate().toInstant());
+
+            // Check if the reminder time is in the past
+            if (triggerTime.before(new Date())) {
+                log.warn("Reminder date is in the past for reminder ID: {}. Skipping scheduling.", reminder.getId());
+                return;
+            }
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity("reminder-trigger-" + reminder.getId(), groupName)
+                    .startAt(triggerTime)
+                    .build();
+
+            scheduler.scheduleJob(jobDetail, trigger);
+            log.info("Scheduled reminder job for reminder ID: {} at {}", reminder.getId(), reminder.getReminderDate());
+
+        } catch (SchedulerException e) {
+            log.error("Failed to schedule reminder job for reminder ID: {}", reminder.getId(), e);
+        }
+    }
+
+    public void cancelReminder(Long reminderId) {
+        try {
+            String jobName = "reminder-job-" + reminderId;
+            String groupName = "reminder-group";
+            JobKey jobKey = JobKey.jobKey(jobName, groupName);
+            
+            boolean deleted = scheduler.deleteJob(jobKey);
+            if (deleted) {
+                log.info("Cancelled reminder job for reminder ID: {}", reminderId);
+            } else {
+                log.warn("No job found to cancel for reminder ID: {}", reminderId);
+            }
+        } catch (SchedulerException e) {
+            log.error("Failed to cancel reminder job for reminder ID: {}", reminderId, e);
+        }
+    }
+
+    public void rescheduleReminder(Reminder reminder) {
+        cancelReminder(reminder.getId());
+        scheduleReminder(reminder);
+    }
+
+    public boolean isReminderScheduled(Long reminderId) {
+        try {
+            String jobName = "reminder-job-" + reminderId;
+            String groupName = "reminder-group";
+            JobKey jobKey = JobKey.jobKey(jobName, groupName);
+            return scheduler.checkExists(jobKey);
+        } catch (SchedulerException e) {
+            log.error("Failed to check if reminder job exists for reminder ID: {}", reminderId, e);
+            return false;
+        }
+    }
+}

--- a/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/ReminderService.java
+++ b/backend/seniorsync/src/main/java/orangle/seniorsync/crm/reminder/service/ReminderService.java
@@ -1,5 +1,6 @@
 package orangle.seniorsync.crm.reminder.service;
 
+import lombok.extern.slf4j.Slf4j;
 import orangle.seniorsync.crm.reminder.dto.CreateReminderDto;
 import orangle.seniorsync.crm.reminder.dto.ReminderDto;
 import orangle.seniorsync.crm.reminder.dto.UpdateReminderDto;
@@ -8,10 +9,13 @@ import orangle.seniorsync.crm.reminder.mapper.ReminderMapper;
 import orangle.seniorsync.crm.reminder.mapper.UpdateReminderMapper;
 import orangle.seniorsync.crm.reminder.model.Reminder;
 import orangle.seniorsync.crm.reminder.repository.ReminderRepository;
+import orangle.seniorsync.crm.staffmanagement.model.Staff;
+import orangle.seniorsync.crm.staffmanagement.repository.StaffRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 public class ReminderService implements IReminderService {
 
@@ -20,13 +24,26 @@ public class ReminderService implements IReminderService {
     private final CreateReminderMapper createReminderMapper;
     private final UpdateReminderMapper updateReminderMapper;
     private final INotificationService notificationService;
+    private final QuartzReminderSchedulerService schedulerService;
+    private final StaffRepository staffRepository;
+    private final IEmailService emailService;
 
-    public ReminderService(ReminderRepository reminderRepository, ReminderMapper reminderMapper, CreateReminderMapper createReminderMapper, UpdateReminderMapper updateReminderMapper, INotificationService notificationService) {
+    public ReminderService(ReminderRepository reminderRepository, 
+                          ReminderMapper reminderMapper, 
+                          CreateReminderMapper createReminderMapper, 
+                          UpdateReminderMapper updateReminderMapper, 
+                          INotificationService notificationService,
+                          QuartzReminderSchedulerService schedulerService,
+                          StaffRepository staffRepository,
+                          IEmailService emailService) {
         this.reminderRepository = reminderRepository;
         this.reminderMapper = reminderMapper;
         this.createReminderMapper = createReminderMapper;
         this.updateReminderMapper = updateReminderMapper;
         this.notificationService = notificationService;
+        this.schedulerService = schedulerService;
+        this.staffRepository = staffRepository;
+        this.emailService = emailService;
     }
 
     @Override
@@ -44,7 +61,8 @@ public class ReminderService implements IReminderService {
 
     /**
      * Creates a new reminder based on the provided DTO.
-     * Maps the DTO to an entity, saves it to the repository, and returns the created request as a DTO.
+     * Maps the DTO to an entity, saves it to the repository, schedules it with Quartz,
+     * and returns the created request as a DTO.
      * Also sends an email notification to the assigned staff member.
      *
      * @param createReminderDto the DTO containing the details of the reminder to be created
@@ -54,6 +72,9 @@ public class ReminderService implements IReminderService {
     public ReminderDto createReminder(CreateReminderDto createReminderDto) {
         Reminder reminderToCreate = createReminderMapper.toEntity(createReminderDto);
         Reminder createdReminder = reminderRepository.save(reminderToCreate);
+        
+        // Schedule the reminder with Quartz
+        schedulerService.scheduleReminder(createdReminder);
         
         // Send notification email if reminder is assigned to a staff member (async)
         if (createdReminder.getStaffAssigneeId() != null) {
@@ -71,12 +92,36 @@ public class ReminderService implements IReminderService {
         updateReminderMapper.updateExistingReminderFromDto(updateReminderDto, reminderToUpdate);
 
         Reminder updatedReminder = reminderRepository.save(reminderToUpdate);
+        
+        // Reschedule the reminder with updated time
+        schedulerService.rescheduleReminder(updatedReminder);
+        
         return reminderMapper.toDto(updatedReminder);
     }
 
+    @Override
     public void deleteReminder(long id) {
         Reminder existingReminder = reminderRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Request not found with ID: " + id));
+                .orElseThrow(() -> new IllegalArgumentException("Reminder not found with ID: " + id));
+        
+        // Cancel the scheduled job before deleting
+        schedulerService.cancelReminder(id);
+        
         reminderRepository.delete(existingReminder);
+    }
+
+    /**
+     * Sends a reminder notification for a specific reminder ID.
+     * This method is called by the Quartz job when a reminder is due.
+     *
+     * @param reminderId the ID of the reminder to send
+     */
+    public void sendReminderById(Long reminderId) {
+        reminderRepository.findById(reminderId).ifPresentOrElse(reminder -> {
+            log.info("Sending reminder notification for reminder ID: {}", reminder.getId());
+            notificationService.notifyReminderTriggered(reminder);
+        }, () -> {
+            log.warn("Reminder with ID {} not found. It may have been deleted.", reminderId);
+        });
     }
 }


### PR DESCRIPTION
this PR changes the reminder pickup functionality to use quartz job instead of scheduled cron job to pickup daily reminders
- each reminder is stored as a quartz job with a `send_at` variable to execute reminder at set time when reminder is created.
- this reminder survives edits as `send_at` variable can be changed